### PR TITLE
Fix low-risk QC/post-processing bugs (no catalog outputs change)

### DIFF
--- a/3_post_processing/get_waveform_amplitude.py
+++ b/3_post_processing/get_waveform_amplitude.py
@@ -373,7 +373,10 @@ def main(argv=None):
                                   for m in ['max_amp', 'min_amp', 'duration']])
                 logging.info("\n%s", picks_df.loc[sample_mask, cols_to_show].head())
         # print the last few rows for verification
-        print(picks_df.loc[mask].tail())
+        # `mask` is only defined when this event produced measurements; guard so
+        # the first event with no data does not raise NameError.
+        if measurements:
+            print(picks_df.loc[mask].tail())
         
         # Save intermediate products every N earthquakes to avoid data loss
         if i % args.save_frequency == 0:

--- a/4_relocation/event_waveform_processing.py
+++ b/4_relocation/event_waveform_processing.py
@@ -373,7 +373,10 @@ def main(argv=None):
                                   for m in ['max_amp', 'min_amp', 'duration']])
                 logging.info("\n%s", picks_df.loc[sample_mask, cols_to_show].head())
         # print the last few rows for verification
-        print(picks_df.loc[mask].tail())
+        # `mask` is only defined when this event produced measurements; guard so
+        # the first event with no data does not raise NameError.
+        if measurements:
+            print(picks_df.loc[mask].tail())
         
         # Save intermediate products every N earthquakes to avoid data loss
         if i % args.save_frequency == 0:

--- a/utils/qc_utils.py
+++ b/utils/qc_utils.py
@@ -503,7 +503,7 @@ def calc_snr(all_picks,all_pick_assignments):
                 noise_abs = np.percentile(abs(noise[0].data),percentile)
                 signal_abs = np.percentile(abs(signal[0].data),percentile)
 
-                snr = 20 * np.log10((signal_abs/noise_abs))
+                snr = 20 * np.log10(signal_abs / noise_abs) if (noise_abs > 0 and signal_abs > 0) else np.nan
 
                 snr_list.append(snr)
 #                 sta_list.append(i[1])
@@ -691,7 +691,7 @@ def calc_snr(all_picks,all_pick_assignments):
                 noise_abs = np.percentile(abs(noise[0].data),percentile)
                 signal_abs = np.percentile(abs(signal[0].data),percentile)
 
-                snr = 20 * np.log10((signal_abs/noise_abs))
+                snr = 20 * np.log10(signal_abs / noise_abs) if (noise_abs > 0 and signal_abs > 0) else np.nan
 
                 snr_list.append(snr)
 #                 sta_list.append(i[1])
@@ -876,7 +876,7 @@ def calc_snr(all_picks,all_pick_assignments):
                 noise_abs = np.percentile(abs(noise[0].data),percentile)
                 signal_abs = np.percentile(abs(signal[0].data),percentile)
 
-                snr = 20 * np.log10((signal_abs/noise_abs))
+                snr = 20 * np.log10(signal_abs / noise_abs) if (noise_abs > 0 and signal_abs > 0) else np.nan
 
                 snr_list.append(snr)
 #                 sta_list.append(i[1])


### PR DESCRIPTION
## Summary

Fixes four low-risk bugs found in a QC / post-processing audit. **None of these change any published catalog output** — they fix a display bug, two crash bugs, and a divide-by-zero in an unused-by-the-filter metric.

The amplitude-plot fix resolves the undergrad reports about ARIDs **999395, 999382, 999384, 178428**: the *amplitude values were always correct*, but the full-window QC plot misplaced the pick marker and amplitude window, so the true peak appeared to fall outside the purple band.

## Changes

| File | Fix |
|------|-----|
| `4_relocation/quality_control/examine_..._w_amp.ipynb` | Both plot functions: replaced the fake `np.linspace(-window_before, window_after, npts)` time axis with `tr.times(reftime=time_pick)` (honors `tr.stats.starttime`); added `sdata.merge(method=1)` so gappy multi-segment channels are plotted/selected as one record instead of only `tr_select[0]`. Display-only. |
| `4_relocation/event_waveform_processing.py` | Guard `print(picks_df.loc[mask])` with `if measurements:` — `mask` was undefined for the first event with no data → `NameError`. |
| `3_post_processing/get_waveform_amplitude.py` | Same crash guard. |
| `utils/qc_utils.py` (`calc_snr`, 3 sites) | Guard `20*log10(signal/noise)` against zero amplitudes → `NaN` instead of `inf`/`-inf`. Not used by the QC pass/fail filter. |

## Why these are safe

- Amplitude plot: cosmetic; the stored `Amplitude` values (from `calculate_amplitudes.py`) are unchanged and were verified correct.
- The two batch scripts are superseded by `calculate_amplitudes.py`; the fix only prevents a crash.
- `calc_snr`'s SNR column is not consumed by the `rms<2.5 & p_picks>4 & s_picks>4` filter.

## Verification

- All three `.py` files pass `python -m py_compile`.
- Notebook re-parses; embedded outputs untouched (diff confined to the two function cells).

## Deliberately NOT included (change outputs / need a decision)

- **QC pick-count threshold**: `qc_metrics_..._cc.ipynb` uses `p_picks > 4 & s_picks > 4` (≥5), but the output file is named `..._p_4_s_4_...` (≥4). Reconcile intent before changing the catalog.
- Morton nearest-neighbor match has no acceptance threshold; `concat_anss` does no dedup / magnitude-type reconciliation.
- Aligning the qc_metrics pick-assignment inputs to the `_cc` catalog version.
- Removing the `3_post_processing` ↔ `4_relocation` duplicate files; rewriting hardcoded `/wd1//home/hbito` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)