### PR TITLE
QC filter: require >= 4 P and >= 4 S picks (was > 4 / >= 5)

### DIFF
--- a/3_post_processing/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb
+++ b/3_post_processing/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb
@@ -683,7 +683,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### P and S Picks > 4 and RMS < 2.5"
+    "#### P and S Picks >= 4 and RMS < 2.5"
    ]
   },
   {
@@ -706,7 +706,7 @@
     "plt.figure(figsize=(8, 8))\n",
     "\n",
     "# Filter and sort the data\n",
-    "_df = df[(df.rms<2.5) & (df.p_picks > 4) & (df.s_picks > 4)].sort_values('rms', ascending=False)\n",
+    "_df = df[(df.rms<2.5) & (df.p_picks >= 4) & (df.s_picks >= 4)].sort_values('rms', ascending=False)\n",
     "\n",
     "# Create the scatter plot\n",
     "scatter = plt.scatter(\n",
@@ -721,7 +721,7 @@
     "# Add labels, title, and axis limits\n",
     "plt.xlabel('Longitude (°)')\n",
     "plt.ylabel('Latitude (°)')\n",
-    "plt.title(f'Events with P and S Picks > 4 and RMS < 2.5\\nNum. Events: {len(_df)}')\n",
+    "plt.title(f'Events with P and S Picks >= 4 and RMS < 2.5\\nNum. Events: {len(_df)}')\n",
     "plt.xlim(-131, -119)\n",
     "plt.ylim(38, 52)\n",
     "\n",
@@ -2475,7 +2475,7 @@
     "\n",
     "# # Filter and sort the data\n",
     "# tol_deg = 25\n",
-    "# _df = df[(df.rms < 1.5) & (abs(180 - df.gap) < tol_deg) & (df.p_picks > 4) & (df.s_picks > 4)].sort_values('rms', ascending=True)\n",
+    "# _df = df[(df.rms < 1.5) & (abs(180 - df.gap) < tol_deg) & (df.p_picks >= 4) & (df.s_picks >= 4)].sort_values('rms', ascending=True)\n",
     "\n",
     "# # Set up figure\n",
     "# plt.figure(figsize=(10, 10))\n",
@@ -2507,7 +2507,7 @@
     "# cbar.ax.set_position([0.85, 0.3, 0.03, 0.4])\n",
     "\n",
     "# # Title\n",
-    "# plt.title(f'Events with P and S Picks > 4, RMS < 1.5 and Gap = 180 ± {tol_deg} (°)\\nNum. Events: {len(_df)}')\n",
+    "# plt.title(f'Events with P and S Picks >= 4, RMS < 1.5 and Gap = 180 ± {tol_deg} (°)\\nNum. Events: {len(_df)}')\n",
     "\n",
     "# plt.tight_layout()\n",
     "# plt.show()\n"

--- a/4_relocation/quality_control/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb
+++ b/4_relocation/quality_control/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb
@@ -683,7 +683,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### P and S Picks > 4 and RMS < 2.5"
+    "#### P and S Picks >= 4 and RMS < 2.5"
    ]
   },
   {
@@ -706,7 +706,7 @@
     "plt.figure(figsize=(8, 8))\n",
     "\n",
     "# Filter and sort the data\n",
-    "_df = df[(df.rms<2.5) & (df.p_picks > 4) & (df.s_picks > 4)].sort_values('rms', ascending=False)\n",
+    "_df = df[(df.rms<2.5) & (df.p_picks >= 4) & (df.s_picks >= 4)].sort_values('rms', ascending=False)\n",
     "\n",
     "# Create the scatter plot\n",
     "scatter = plt.scatter(\n",
@@ -721,7 +721,7 @@
     "# Add labels, title, and axis limits\n",
     "plt.xlabel('Longitude (°)')\n",
     "plt.ylabel('Latitude (°)')\n",
-    "plt.title(f'Events with P and S Picks > 4 and RMS < 2.5\\nNum. Events: {len(_df)}')\n",
+    "plt.title(f'Events with P and S Picks >= 4 and RMS < 2.5\\nNum. Events: {len(_df)}')\n",
     "plt.xlim(-131, -119)\n",
     "plt.ylim(38, 52)\n",
     "\n",
@@ -2475,7 +2475,7 @@
     "\n",
     "# # Filter and sort the data\n",
     "# tol_deg = 25\n",
-    "# _df = df[(df.rms < 1.5) & (abs(180 - df.gap) < tol_deg) & (df.p_picks > 4) & (df.s_picks > 4)].sort_values('rms', ascending=True)\n",
+    "# _df = df[(df.rms < 1.5) & (abs(180 - df.gap) < tol_deg) & (df.p_picks >= 4) & (df.s_picks >= 4)].sort_values('rms', ascending=True)\n",
     "\n",
     "# # Set up figure\n",
     "# plt.figure(figsize=(10, 10))\n",
@@ -2507,7 +2507,7 @@
     "# cbar.ax.set_position([0.85, 0.3, 0.03, 0.4])\n",
     "\n",
     "# # Title\n",
-    "# plt.title(f'Events with P and S Picks > 4, RMS < 1.5 and Gap = 180 ± {tol_deg} (°)\\nNum. Events: {len(_df)}')\n",
+    "# plt.title(f'Events with P and S Picks >= 4, RMS < 1.5 and Gap = 180 ± {tol_deg} (°)\\nNum. Events: {len(_df)}')\n",
     "\n",
     "# plt.tight_layout()\n",
     "# plt.show()\n"


### PR DESCRIPTION
## ⚠️ This changes a published catalog output

The QC threshold filter used `p_picks > 4 & s_picks > 4`, i.e. it required **≥5** P and **≥5** S picks — but the output file is named `..._p_4_s_4_...` and the methods describe a minimum of **4**. Per decision, change the code to match the documented (and more generous) **≥4** threshold.

**Effect:** events with exactly 4 P and/or exactly 4 S picks (and `RMS < 2.5`) now pass QC. The filtered catalog `origin_2010_2015_reloc_cog_ver3_cc_p_4_s_4_rms_2_5.csv` will contain **more** events. **The notebook must be re-run to regenerate that CSV** — this PR only changes the code, not the CSV.

## Change

`(df.p_picks > 4) & (df.s_picks > 4)` → `(df.p_picks >= 4) & (df.s_picks >= 4)`

Applied to the active filter, the plot title (`P and S Picks > 4` → `>= 4`), and the commented gap-filter variant, in both tracked copies:
- `3_post_processing/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb`
- `4_relocation/quality_control/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb`

Diff is 10 lines per file; embedded outputs untouched.

## Notes

- A third, **untracked** duplicate `4_relocation/qc_metrics_all_regions_reloc_cog_ver3_cc.ipynb` exists in the working tree with the old `> 4` threshold. It is not in version control; recommend deleting it or consolidating the three copies so they can't diverge.
- Independent of #8 (low-risk display/crash fixes); both can merge separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)